### PR TITLE
LCD1602的RW接rpi的PIN30, 修改DHT11.py timecount变量未分配前被引用的bug

### DIFF
--- a/DHT11.py
+++ b/DHT11.py
@@ -34,7 +34,7 @@ lcd_backlight = 4
 lcd_columns = 16
 lcd_rows    = 2
 
-
+timecount = 0
 # Initialize the LCD using the pins above.
 lcd = LCD.Adafruit_CharLCD(lcd_rs, lcd_en, lcd_d4, lcd_d5, lcd_d6, lcd_d7,lcd_columns, lcd_rows, lcd_backlight)
 while True:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ VO，液晶对比度调节，接1K 电阻，另一端相连接地，PIN 9
 
 RS，寄存器选择，接GPIO 14，RPi PIN 8
 
-RW，读写选择，接地，表示写模式，PRi PIN 6
+RW，读写选择，接地，表示写模式，PRi PIN 30
 
 E，使能信号，接GPIO 15，RPi PIN 10
 
@@ -140,12 +140,12 @@ sudo python setup.py install
 # 安装
 ```bash
 cd /var/www/html
-git clone  https://github.com/yfgeek/rpi-TempRuntime.git
+git clone https://github.com/yfgeek/rpi-TempRuntime.git
 ```
 # 运行
 ```bash
 cd /var/www/html/rpi-TempRuntime
-python LCD.py
+python DHT11.py
 ```
 # 结果
 


### PR DESCRIPTION
你好, 感谢你的开源代码, 造福新手.
我在试的过程中发现两个小问题:

> VSS，接地，RPi PIN 6
> ...
> RW，读写选择，接地，表示写模式，PRi PIN 6

这里 VSS 和 RW 都接了 RPI PIN 6. 我试着 RW 接了 PIN 30, 也成功了, 不知道会不会有潜在的问题.

另外 `python DHT11.py` 会有 `timecount` 变量未分配的问题.